### PR TITLE
Remove named comment for non-ORCID/ROR identifiers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-0250-5673")),
     person("Qing-Song", "Xu", email = "qsxu@csu.edu.cn", role = c("aut")),
     person("Dong-Sheng", "Cao", role = "aut"),
-    person("Sebastian", "Mueller", role = "ctb",
-           comment = c(company = "Alva Genomics"))
+    person("Sebastian", "Mueller", role = "ctb", comment = "Alva Genomics")
     )
 License: BSD_3_clause + file LICENSE
 URL: https://nanx.me/protr/, https://github.com/nanxstats/protr, http://protr.org


### PR DESCRIPTION
This PR fixes an `R CMD check` note that only happens on Debian r-devel build machines on CRAN since earlier this year.

## Problem

R CMD check produces a NOTE on r-devel Debian environments (debian-clang, debian-gcc) about "Author field differs from that derived from Authors@R" when using named comments in `Authors@R` that are not `ORCID` or `ROR` identifiers.

## Root cause

When `person()` in `Authors@R` has a named comment like `comment = c(company = "Acme Corporation")`:

1. `format.person()` calls `.expand_person_comment_identifiers()` which only processes ORCID/ROR.
2. Non-ORCID/ROR named comments remain named and get formatted as `"name: value"`.
3. The `R CMD check` code in tools [check.R](https://github.com/r-devel/r-svn/blob/a05bd9c2b593b19a15be19cd5c04e793a55b72f3/src/library/tools/R/check.R#L1050-L1123) only has workarounds to strip `"ORCID:"` and `"ROR:"` prefixes.
4. Any other named comment causes a mismatch: (`company: Acme Corporation`) vs. expected (`Acme Corporation`).

## Solution

Change `comment = c(company = "Acme Corporation")` to `comment = "Acme Corporation"` (unnamed).

Only ORCID and ROR should use named comments as they have special handling in R's formatting pipeline.